### PR TITLE
fix(M4Pro): add corporate SSL certificate config

### DIFF
--- a/hosts/M4Pro/default.nix
+++ b/hosts/M4Pro/default.nix
@@ -8,7 +8,7 @@ in
     home.sessionVariables = {
       DENO_CERT = customCert;
       NODE_EXTRA_CA_CERTS = customCert;
+      GIT_SSL_CAINFO = customCert;
     };
-    programs.git.settings.http.sslCAInfo = customCert;
   };
 }


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

fixes #4

## Changes

- Add host-specific SSL certificate configuration to `hosts/M4Pro/default.nix` for corporate proxy
  - `DENO_CERT` — deno が JSR パッケージを取得する際の SSL 検証に使用
  - `NODE_EXTRA_CA_CERTS` — Node.js の SSL 検証に使用
  - `git http.sslCAInfo` — git の HTTPS 通信に使用
- 証明書パスを `~/.local/share/ca-certificates/corp.pem` に統一し、`customCert` 変数で一元管理

## Verification

- [x] No lint/type errors
- [x] No breaking changes introduced
- [x] Changeset file created (if needed for version bump)

## Additional Notes

会社 Mac の SSL インスペクションにより、deno が JSR (`jsr.io`) へアクセスする際に `invalid peer certificate: UnknownIssuer` エラーが発生し、zeno.zsh のソケットサーバー起動に失敗していた。スペースキー・エンターキーが zeno の widget にバインドされているため、シェルが操作不能になる問題が起きていた。